### PR TITLE
feat: remove USE_TCMALLOC macro definition

### DIFF
--- a/zmalloc.h
+++ b/zmalloc.h
@@ -35,17 +35,17 @@
 #define __xstr(s) __xsstr(s)
 #define __xsstr(s) #s
 
-#if defined(USE_TCMALLOC)
-#define ZMALLOC_LIB ("tcmalloc-" __xstr(TC_VERSION_MAJOR) "." __xstr(TC_VERSION_MINOR))
-#include <google/tcmalloc.h>
-#if (TC_VERSION_MAJOR == 1 && TC_VERSION_MINOR >= 6) || (TC_VERSION_MAJOR > 1)
-#define HAVE_MALLOC_SIZE 1
-#define zmalloc_size(p) tc_malloc_size(p)
-#else
-#error "Newer version of tcmalloc required"
-#endif
+// #if defined(USE_TCMALLOC)
+// #define ZMALLOC_LIB ("tcmalloc-" __xstr(TC_VERSION_MAJOR) "." __xstr(TC_VERSION_MINOR))
+// #include <google/tcmalloc.h>
+// #if (TC_VERSION_MAJOR == 1 && TC_VERSION_MINOR >= 6) || (TC_VERSION_MAJOR > 1)
+// #define HAVE_MALLOC_SIZE 1
+// #define zmalloc_size(p) tc_malloc_size(p)
+// #else
+// #error "Newer version of tcmalloc required"
+// #endif
 
-#elif defined(USE_JEMALLOC)
+#if defined(USE_JEMALLOC)
 #define ZMALLOC_LIB ("jemalloc-" __xstr(JEMALLOC_VERSION_MAJOR) "." __xstr(JEMALLOC_VERSION_MINOR) "." __xstr(JEMALLOC_VERSION_BUGFIX))
 #include <jemalloc/jemalloc.h>
 #if (JEMALLOC_VERSION_MAJOR == 2 && JEMALLOC_VERSION_MINOR >= 1) || (JEMALLOC_VERSION_MAJOR > 2)


### PR DESCRIPTION
remove USE_TCMALLOC macro definition，then we can use jemalloc as same as Pika in PikiwiDB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The application now defaults to using Jemalloc for memory allocation, enhancing performance and memory management.
- **Bug Fixes**
	- Removed the TCMalloc configuration, eliminating potential compatibility issues related to memory allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->